### PR TITLE
Improve layer compatibility

### DIFF
--- a/config.el
+++ b/config.el
@@ -1,1 +1,2 @@
-(spacemacs|defvar-company-backends merlin-mode)
+(defvar-local reason-auto-refmt t
+  "Whether to automatcally run refmt on save in the current reason-mode buffer.")

--- a/funcs.el
+++ b/funcs.el
@@ -1,6 +1,10 @@
-
 (defun reason/rtop-prompt ()
   "The rtop prompt function."
   (let ((prompt (format "rtop[%d]> " utop-command-number)))
     (add-text-properties 0 (length prompt) '(face utop-prompt) prompt)
     prompt))
+
+(defun reason/refmt-before-save ()
+  "Before save hook for automatic refmt."
+  (when reason-auto-refmt
+      (refmt)))

--- a/layers.el
+++ b/layers.el
@@ -1,0 +1,1 @@
+(configuration-layer/declare-layer 'ocaml)


### PR DESCRIPTION
- Introduce per-buffer toggle to run refmt automatically on save

    Default to on, and provide a variable `reason-auto-refmt` to override in a layer variable.

- Codify dependence on ocaml layer
- Defer loading of reason-mode
- Configure refmt errors window using popwin instead of `display-buffers-alist`
- Add which-key group names for reaosn-mode key bindings
- Use `spacemacs|add-company-backends` instead of piecemeal merlin/company config

    This conflicts with recommendations from the [layers docs](https://github.com/syl20bnr/spacemacs/blob/develop/doc/LAYERS.org),
    but it seems to be what most actual layers do? It seems to be working for me, and it looks much cleaner.

- Default utop config to using `rtop` from $PATH instead of assuming it's installed via opam

    This works better with globally installed `reason-cli` toolchain per the recommendation in
    the [reason Getting Started docs](https://facebook.github.io/reason/gettingStarted.html#javascript-workflow-editor-setup-global-utilities).

This has been working better for me locally, but it would be great to get someone else to try it out and see if it's solid. 